### PR TITLE
Certificate handling for ATEC608B and ESP32S3

### DIFF
--- a/components/esp-tls/Kconfig
+++ b/components/esp-tls/Kconfig
@@ -15,7 +15,7 @@ menu "ESP-TLS"
 
     config ESP_TLS_USE_SECURE_ELEMENT
         bool "Use Secure Element (ATECC608A) with ESP-TLS"
-        depends on IDF_TARGET_ESP32 && ESP_TLS_USING_MBEDTLS
+        depends on ESP_TLS_USING_MBEDTLS
         select ATCA_MBEDTLS_ECDSA
         select ATCA_MBEDTLS_ECDSA_SIGN
         select ATCA_MBEDTLS_ECDSA_VERIFY

--- a/components/esp-tls/esp_tls.h
+++ b/components/esp-tls/esp_tls.h
@@ -211,6 +211,9 @@ typedef struct esp_tls_cfg {
     const int *ciphersuites_list;           /*!< Pointer to a zero-terminated array of IANA identifiers of TLS ciphersuites.
                                                 Please check the list validity by esp_tls_get_ciphersuites_list() API */
     esp_tls_proto_ver_t tls_version;        /*!< TLS protocol version of the connection, e.g., TLS 1.2, TLS 1.3 (default - no preference) */
+#ifdef CONFIG_ATECC608A_RUNTIME_SELECTION
+    uint8_t atecc608a_i2c_addr;            /*!< I2C address of the atecc608a chip */
+#endif // CONFIG_ATECC608A_RUNTIME_SELECTION
 } esp_tls_cfg_t;
 
 #if defined(CONFIG_ESP_TLS_SERVER_SESSION_TICKETS)
@@ -320,6 +323,10 @@ typedef struct esp_tls_cfg_server {
     esp_tls_handshake_callback cert_select_cb;  /*!< Certificate selection callback that gets called after ClientHello is processed.
                                                      Can be used as an SNI callback, but also has access to other
                                                      TLS extensions, such as ALPN and server_certificate_type . */
+#endif
+
+#if defined(CONFIG_ATECC608A_RUNTIME_SELECTION)
+    uint8_t atecc608a_i2c_addr;                 /*!< I2C address of the atecc608a chip */
 #endif
 
 } esp_tls_cfg_server_t;

--- a/components/esp-tls/esp_tls_mbedtls.c
+++ b/components/esp-tls/esp_tls_mbedtls.c
@@ -802,6 +802,14 @@ esp_err_t set_client_config(const char *hostname, size_t hostlen, esp_tls_cfg_t 
 
     if (cfg->use_secure_element) {
 #ifdef CONFIG_ESP_TLS_USE_SECURE_ELEMENT
+#if defined(CONFIG_ATECC608A_RUNTIME_SELECTION)
+        if (cfg->atecc608a_i2c_addr != 0) {
+            tls->atecc608a_i2c_addr = cfg->atecc608a_i2c_addr;
+        } else {
+            ESP_LOGE(TAG, "When using MANUAL SELECTION, i2c address for ATECC608A is required");
+            return ESP_ERR_INVALID_ARG;
+        }
+#endif
         esp_tls_pki_t pki = {
             .public_cert = &tls->clientcert,
             .pk_key = &tls->clientkey,
@@ -1086,7 +1094,27 @@ static esp_err_t esp_set_atecc608a_pki_context(esp_tls_t *tls, const void *pki)
         ESP_LOGE(TAG, "Device certificate must be provided for TrustCustom Certs");
         return ESP_FAIL;
     }
-#endif /* CONFIG_ATECC608A_TCUSTOM */
+#elif CONFIG_ATECC608A_RUNTIME_SELECTION
+    esp_ret = esp_init_atecc608a(tls->atecc608a_i2c_addr);
+    if (ret != ESP_OK) {
+        return ESP_ERR_ESP_TLS_SE_FAILED;
+    }
+    mbedtls_x509_crt_init(&tls->clientcert);
+
+    esp_tls_pki_t *pki_l = (esp_tls_pki_t *) pki;
+    if (pki_l->publiccert_pem_buf != NULL) {
+        ret = mbedtls_x509_crt_parse(&tls->clientcert, pki_l->publiccert_pem_buf, pki_l->publiccert_pem_bytes);
+        if (ret < 0) {
+            ESP_LOGE(TAG, "mbedtls_x509_crt_parse of client cert returned -0x%04X", -ret);
+            mbedtls_print_error_msg(ret);
+            ESP_INT_EVENT_TRACKER_CAPTURE(tls->error_handle, ESP_TLS_ERR_TYPE_MBEDTLS, -ret);
+            return ESP_ERR_MBEDTLS_X509_CRT_PARSE_FAILED;
+        }
+    } else {
+        ESP_LOGE(TAG, "Device certificate must be provided for manual setup");
+        return ESP_FAIL;
+    }
+#endif /* CONFIG_ATECC608A_RUNTIME_SELECTION */
     ret = atca_mbedtls_pk_init(&tls->clientkey, 0);
     if (ret != 0) {
         ESP_LOGE(TAG, "Failed to parse key from device");

--- a/components/esp-tls/private_include/esp_tls_private.h
+++ b/components/esp-tls/private_include/esp_tls_private.h
@@ -93,7 +93,9 @@ struct esp_tls {
                                                                                      - ESP_TLS_SERVER */
 
     esp_tls_error_handle_t error_handle;                                        /*!< handle to error descriptor */
-
+#ifdef CONFIG_ATECC608A_RUNTIME_SELECTION
+    uint8_t atecc608a_i2c_addr;                                                 /*!< I2C address of the ATECC608A device */
+#endif // CONFIG_ATECC608A_RUNTIME_SELECTION
 };
 
 // Function pointer for the server configuration API

--- a/components/esp_http_client/esp_http_client.c
+++ b/components/esp_http_client/esp_http_client.c
@@ -755,7 +755,11 @@ esp_http_client_handle_t esp_http_client_init(const esp_http_client_config_t *co
 
 #if CONFIG_ESP_TLS_USE_SECURE_ELEMENT
     if (config->use_secure_element) {
+#ifdef CONFIG_ATECC608A_RUNTIME_SELECTION
+        esp_transport_ssl_use_secure_element(ssl, config->atecc608a_i2c_addr);
+#else // CONFIG_ATECC608A_RUNTIME_SELECTION
         esp_transport_ssl_use_secure_element(ssl);
+#endif // CONFIG_ATECC608A_RUNTIME_SELECTION
     }
 #endif
 

--- a/components/esp_http_client/include/esp_http_client.h
+++ b/components/esp_http_client/include/esp_http_client.h
@@ -180,6 +180,9 @@ typedef struct {
     struct ifreq                *if_name;            /*!< The name of interface for data to go through. Use the default interface without setting */
 #if CONFIG_ESP_TLS_USE_SECURE_ELEMENT
     bool use_secure_element;                /*!< Enable this option to use secure element */
+#ifdef CONFIG_ATECC608A_RUNTIME_SELECTION
+    uint8_t atecc608a_i2c_addr;             /*!< ATECC608A I2C address */
+#endif // CONFIG_ATECC608A_RUNTIME_SELECTION
 #endif
 #if CONFIG_ESP_TLS_USE_DS_PERIPHERAL
     void *ds_data;                          /*!< Pointer for digital signature peripheral context, see ESP-TLS Documentation for more details */

--- a/components/esp_https_server/include/esp_https_server.h
+++ b/components/esp_https_server/include/esp_https_server.h
@@ -116,6 +116,9 @@ struct httpd_ssl_config {
     /** Enable secure element for server session */
     bool use_secure_element;
 
+    /** ATECC608A I2C address, used for secure element */
+    uint8_t atecc608a_i2c_addr;
+
     /** User callback for esp_https_server */
     esp_https_server_user_cb *user_cb;
 

--- a/components/tcp_transport/include/esp_transport_ssl.h
+++ b/components/tcp_transport/include/esp_transport_ssl.h
@@ -169,8 +169,13 @@ void esp_transport_ssl_set_common_name(esp_transport_handle_t t, const char *com
  * @note       Recommended to be used with ESP32 interfaced to ATECC608A based secure element
  *
  * @param      t     ssl transport
+ * @param      atecc608a_i2c_addr i2c address of the ATECC608A chip to use
  */
+#ifdef CONFIG_ATECC608A_RUNTIME_SELECTION
+void esp_transport_ssl_use_secure_element(esp_transport_handle_t t, uint8_t atecc608a_i2c_addr);
+#else
 void esp_transport_ssl_use_secure_element(esp_transport_handle_t t);
+#endif // CONFIG_ATECC608A_RUNTIME_SELECTION
 
 /**
  * @brief      Set the ds_data handle in ssl context.(used for the digital signature operation)

--- a/components/tcp_transport/transport_ssl.c
+++ b/components/tcp_transport/transport_ssl.c
@@ -452,10 +452,17 @@ void esp_transport_ssl_set_common_name(esp_transport_handle_t t, const char *com
 }
 
 #ifdef CONFIG_ESP_TLS_USE_SECURE_ELEMENT
+#ifdef CONFIG_ATECC608A_RUNTIME_SELECTION
+void esp_transport_ssl_use_secure_element(esp_transport_handle_t t, uint8_t atecc608a_i2c_addr)
+#else
 void esp_transport_ssl_use_secure_element(esp_transport_handle_t t)
+#endif // CONFIG_ATECC608A_RUNTIME_SELECTION
 {
     GET_SSL_FROM_TRANSPORT_OR_RETURN(ssl, t);
     ssl->cfg.use_secure_element = true;
+#ifdef CONFIG_ATECC608A_RUNTIME_SELECTION
+    ssl->cfg.atecc608a_i2c_addr = atecc608a_i2c_addr;
+#endif // CONFIG_ATECC608A_RUNTIME_SELECTION
 }
 #endif
 


### PR DESCRIPTION
Make configuration possible for ESP32S3 and add a configuration option for selecting the address during runtime.